### PR TITLE
Link addons with rpath relative to `$ORIGIN` on Linux

### DIFF
--- a/addons.cmake
+++ b/addons.cmake
@@ -101,6 +101,14 @@ else()
     set_target_properties(${ADDON_NAME} PROPERTIES OUTPUT_NAME ${ADDON_OUTPUT_NAME})
 endif() 
 
+# Look for libida one directory up relative to plugin folder, just like official Hex-Rays plugins on Linux
+if(DEFINED __LINUX__)
+    set_target_properties(${ADDON_NAME} PROPERTIES
+        BUILD_WITH_INSTALL_RPATH true
+        INSTALL_RPATH "$ORIGIN/.."
+        LINK_OPTIONS "-Wl,--disable-new-dtags")
+endif()
+
 # Set include directory
 target_include_directories(${ADDON_NAME} PRIVATE ${IDASDK}/include ${ADDON_INCLUDE_DIRECTORIES})
 


### PR DESCRIPTION
Before:
```console
$ readelf -d myplugin64.so
Dynamic section at offset 0x52a60 contains 30 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libida64.so]
 [...]
 0x000000000000001d (RUNPATH)            Library runpath: [/full/path/to/idasdk/lib/x64_linux_gcc_64]
```

After:
```console
$ readelf -d myplugin64.so
Dynamic section at offset 0x1bcf0 contains 35 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libida64.so]
 [...]
 0x000000000000000f (RPATH)              Library rpath: [$ORIGIN/..]
```
Official Hex-Rays plugin:

```console
$ readelf -d idapython3_64.so
Dynamic section at offset 0x1bcf0 contains 35 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libida64.so]
 [...]
 0x000000000000000f (RPATH)              Library rpath: [$ORIGIN/..]
```
