### PR TITLE
Update common.cmake - IDA Pro 9.0 idalib name change

### DIFF
--- a/common.cmake
+++ b/common.cmake
@@ -89,7 +89,7 @@ elseif(UNIX AND NOT APPLE)
     set(IDASLIBPATH64 "${IDALIBPATH64}")
     
     set(IDALIB32 ${IDALIBPATH32}/libida.so)
-    set(IDALIB64 ${IDALIBPATH64}/libida64.so)
+    set(IDALIB64 ${IDALIBPATH64}/libida.so)
     set(IDALIBLIB64 ${IDALIBPATH64}/libidalib.so)
 else()
     message(FATAL_ERROR "Unknown platform!")


### PR DESCRIPTION
Fixes a change in IDA Pro 9.0, libida64.so is now libida.so. Seems to be a change between beta/rc/final.