### PR TITLE
addons: NT output path

### DIFF
--- a/addons.cmake
+++ b/addons.cmake
@@ -131,7 +131,11 @@ if (DEFINED __NT__)
     foreach (cfg IN LISTS CMAKE_CONFIGURATION_TYPES)
         string(TOUPPER ${cfg} cfg)
         set_target_properties(${ADDON_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_${cfg} ${IDABIN}/${ADDON_BIN})
+        set_target_properties(${ADDON_NAME} PROPERTIES PREFIX_${cfg} ""})
     endforeach()
+
+    set_target_properties(${ADDON_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${IDABIN}/${ADDON_BIN})
+    set_target_properties(${ADDON_NAME} PROPERTIES PREFIX "")
 else()
     # Set the destination folder to be in IDA's binary output folder
     set_target_properties(${ADDON_NAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${IDABIN}/${ADDON_BIN})


### PR DESCRIPTION
for __NT__:
  - set the target top level RUNTIME_OUTPUT_DIRECTORY, which was relevant when using `zig cc`
  - clear the prefix, to avoid names like "libmysample.dll"