### PR TITLE
common: recognize aarch64

### DIFF
--- a/common.cmake
+++ b/common.cmake
@@ -67,8 +67,8 @@ elseif(APPLE)
     set(IDAPROPLAT "__MAC__")
     
     set(IDALIBSUFFIX "dylib")
-    
-    if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "arm64")
+
+    if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "arm64" OR ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
         set(IDALIBPATH32 "${IDASDK}/lib/arm64_mac_clang_32")
         set(IDALIBPATH64 "${IDASDK}/lib/arm64_mac_clang_64")
     else()


### PR DESCRIPTION
When using `zig cc` to cross compile, the processor name is `aarch64` rather than `arm64`, and I'm not sure that's easy to tweak. I'd propose accepting both here, rather than debating what the correct term is :-)