### PR TITLE
common: relax Windows detection (remove MSVC check)

### DIFF
--- a/common.cmake
+++ b/common.cmake
@@ -46,7 +46,7 @@ endif()
 message("-- Detected IDA SDK version: ${IDASDK_VERSION}")
 
 # Set libraries path
-if (WIN32 AND MSVC)
+if (WIN32)
     set(__NT__ 1)
     set(IDAPROPLAT   "__NT__")
 


### PR DESCRIPTION
I'm not sure if this is a correct change, so please let's discuss.

When using `zig cc` to cross compile a plugin from macOS, I was able to use the target triple `x86_64-windows-gnu` but not `x86_64-windows-msvc`. But, I had to manually specify `-DMSVC=1` to get ida-cmake to correctly identify the Windows configuration. So, is it reasonable to relax this check?

cc: @mrexodia for zig cross compilation insight and awareness.