### PR TITLE
allow ida-cmake and idasdk to be sibling dirs

### DIFF
--- a/common.cmake
+++ b/common.cmake
@@ -114,7 +114,11 @@ set(IDAPROINCLUDE "${IDASDK}/include")
 # Convenience macro to include the addons script and create the proper targets
 # The addons script can be included many times, each time it generates a new target
 macro(generate)
-    if (DEFINED IDASDK)
+    if (DEFINED IDACMAKE)
+        include(${IDACMAKE}/addons.cmake)
+    elseif  (DEFINED ENV{IDACMAKE})
+        include($ENV{IDACMAKE}/addons.cmake)
+    elseif (DEFINED IDASDK)
         include(${IDASDK}/ida-cmake/addons.cmake)
     elseif (DEFINED ENV{IDASDK})
         include($ENV{IDASDK}/ida-cmake/addons.cmake)

--- a/idasdk.cmake
+++ b/idasdk.cmake
@@ -1,5 +1,10 @@
 include_guard(DIRECTORY)
-if (DEFINED IDASDK)
+
+if (DEFINED IDACMAKE)
+    include(${IDACMAKE}/common.cmake)
+elseif  (DEFINED ENV{IDACMAKE})
+    include($ENV{IDACMAKE}/common.cmake)
+elseif (DEFINED IDASDK)
     include(${IDASDK}/ida-cmake/common.cmake)
 elseif (DEFINED ENV{IDASDK})
     include($ENV{IDASDK}/ida-cmake/common.cmake)


### PR DESCRIPTION
I would like to easily have a single IDA plugin in a git repository and have the setup instructions be relatively simple
> * download the sdk from ida and extract it <here>
> * run cmake

these changes allow for separate configuration of `ida-cmake` and `idasdk` directories so the following directory structure can be supported

```
lib/
    ida-cmake/
    idasdk91/
src/
CMakeLists.txt
```

where CMakeLists.txt looks something like this:
```
cmake_minimum_required(VERSION 3.27 FATAL_ERROR)

project(MyPluginName)

set(CMAKE_CXX_STANDARD 20)

set(ENV{IDASDK} "${PROJECT_SOURCE_DIR}/lib/idasdk91")
set(ENV{IDACMAKE} "${PROJECT_SOURCE_DIR}/lib/ida-cmake")

include(${PROJECT_SOURCE_DIR}/lib/ida-cmake/idasdk.cmake)

set(PLUGIN_NAME     MyPluginName)
set(PLUGIN_SOURCES
        src/plugin.h
        src/plugin.cpp
        src/version.h
)

generate()
```