### PR TITLE
Remove extra } in addons.cmake

### DIFF
--- a/addons.cmake
+++ b/addons.cmake
@@ -131,7 +131,7 @@ if (DEFINED __NT__)
     foreach (cfg IN LISTS CMAKE_CONFIGURATION_TYPES)
         string(TOUPPER ${cfg} cfg)
         set_target_properties(${ADDON_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_${cfg} ${IDABIN}/${ADDON_BIN})
-        set_target_properties(${ADDON_NAME} PROPERTIES PREFIX_${cfg} ""})
+        set_target_properties(${ADDON_NAME} PROPERTIES PREFIX_${cfg} "")
     endforeach()
 
     set_target_properties(${ADDON_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${IDABIN}/${ADDON_BIN})


### PR DESCRIPTION
Removed extra '}' that was preventing cmake from executing on windows w/ visual studios 2022:

Before using hello plugin with the following cmake file:
```
cmake_minimum_required(VERSION 3.27 FATAL_ERROR)

project(hello)

# Plugin 1
set(CMAKE_CXX_STANDARD 17)

include($ENV{IDASDK}/ida-cmake/idasdk.cmake)

set(PLUGIN_NAME              hello)
set(PLUGIN_SOURCES           hello.cpp)
set(PLUGIN_RUN_ARGS          "-t -z10000") # Debug messages for the debugger
generate()
disable_ida_warnings(hello)
```

I would receive:
```
CMake Error at C:/Users/user/source/ida_sdk/ida-cmake/addons.cmake:134 (set_target_properties):     
  set_target_properties called with incorrect number of arguments.
  set_target_properties called with incorrect number of arguments.
  set_target_properties called with incorrect number of arguments.
  set_target_properties called with incorrect number of arguments.
  set_target_properties called with incorrect number of arguments.
  set_target_properties called with incorrect number of arguments.
  set_target_properties called with incorrect number of arguments.
```

After the change the build completes successfully.
