### PR TITLE
fix: swap ida/idalib link order to fix macOS SIGSEGV

### DIFF
--- a/idasdkConfig.cmake
+++ b/idasdkConfig.cmake
@@ -143,12 +143,15 @@ if(NOT TARGET idasdk::idalib)
     )
 
     # Link to platform and compiler settings, plus BOTH idalib and ida libraries
-    # Note: idalib.lib requires ida.lib for some symbols
+    # Note: ida must come BEFORE idalib because both stubs export overlapping
+    # symbols (qvector_reserve, qalloc_or_throw, qfree, etc.), but at runtime
+    # only libida actually provides them. Wrong order causes two-level namespace
+    # binding failures on macOS.
     target_link_libraries(idasdk::idalib INTERFACE
         ida_platform_settings
         ida_compiler_settings
-        "${IDALIB_PATH}"
-        "${IDA_LIB_PATH}")
+        "${IDA_LIB_PATH}"
+        "${IDALIB_PATH}")
 endif()
 
 # Debugger module support (optional, disabled by default)


### PR DESCRIPTION
## Summary

- Swap `IDA_LIB_PATH` before `IDALIB_PATH` in the `idasdk::idalib` target link order to fix a SIGSEGV crash on macOS

## Problem

Both stub dylibs (`libida.dylib` and `libidalib.dylib` in `lib/arm64_mac_clang_64/`) export 184 overlapping symbols including `qvector_reserve`, `qalloc_or_throw`, `qfree`, and `qsnprintf`. With `libidalib` listed first, the macOS linker binds these symbols to it via two-level namespaces.

At runtime, the real `libidalib.dylib` (1.4MB) does **not** export these symbols — only `libida.dylib` does. The dyld lazy resolver fails silently, resolving all four IDA memory functions to a garbage fallback address (`0x19bb0a6f8`), causing SIGSEGV on any `qstring` construction.

Verified with `DYLD_PRINT_BINDINGS=1`:
```
# BEFORE (broken): all resolve to same <none> address
<idasql/bind#459> -> 0x19bb0a6f8 <<none>/_qvector_reserve>

# AFTER (fixed): correctly resolve from libida
<idasql/bind#459> -> 0x106fdd3f0 <libida.dylib/_qvector_reserve>
```

## Test plan

- [x] `qstring` construction no longer crashes
- [x] All idasql virtual tables work (`welcome`, `funcs`, `segments`, etc.)
- [x] HTTP server mode works end-to-end
- [x] Harmless on Linux/Windows (flat namespace / explicit import libs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)