### PR TITLE
fix: detect ARM64 architecture on Linux

### DIFF
--- a/cmake/platform.cmake
+++ b/cmake/platform.cmake
@@ -78,7 +78,11 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(IDA_PLATFORM "LINUX")
     set(IDA_PLATFORM_NAME "linux")
-    set(IDA_ARCH "x64")
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
+        set(IDA_ARCH "arm64")
+    else()
+        set(IDA_ARCH "x64")
+    endif()
     set(IDAPROPLAT "__LINUX__")
 
     # Compiler detection for Linux


### PR DESCRIPTION
## Summary
- The Linux block in `platform.cmake` hardcodes `IDA_ARCH` to `"x64"`, ignoring ARM64 hosts
- On aarch64 Linux, the build system selects `x64_linux_64/libida.so` instead of `arm64_linux_64/libida.so`, causing "file in wrong format" linker errors
- The macOS block already has this check (line 71) — this adds the same pattern to Linux

## Test plan
- Build an IDA SDK plugin on ARM64 Linux (e.g., Raspberry Pi 5, AWS Graviton) and verify it links against `arm64_linux_64/` libraries
- Verify x64 Linux builds are unaffected (falls through to the `else` branch)