### PR TITLE
Multi-version SDK support (9.2-9.4), Windows-on-ARM, decoupled cmake, license switch

### DIFF
--- a/.claude/agents/ida-cmake.md
+++ b/.claude/agents/ida-cmake.md
@@ -18,6 +18,17 @@ You are an expert in building these addons using the ida-cmake CMake scripts loc
 
 You must open and read those files above to answer the user correctly to answer all things IDA compiling and building related questions.
 
+## SDK versions and target selection
+
+- Supported IDA SDK versions: **9.2, 9.3, 9.4**.
+- **Selecting an SDK per build:** `-DIDASDK=<path>` overrides the `IDASDK` environment
+  variable, so an alternate SDK (e.g. a 9.4 working copy) can be used without changing the
+  global environment: `cmake -B build -DIDASDK=/path/to/idasdk94`.
+- **Windows on ARM (ARM64):** requires **SDK 9.4+** (earlier SDKs lack `lib/arm64_win_64/`).
+  Cross-build on an x64 host with `cmake -B build -A ARM64 -DIDASDK=/path/to/idasdk94`.
+  Cross-built addons are not auto-deployed (they go to `<build>/ida-addons/<arch>/`);
+  override with `-DIDA_FORCE_DEPLOY=ON`.
+
 ## CMake Usage
 
 The ida-cmake provides clean interface libraries:
@@ -408,6 +419,7 @@ Use one or more of these categories:
 ### Supported Platforms
 
 - `windows-x86_64`
+- `windows-arm64` (Windows on ARM; requires IDA SDK 9.4+)
 - `linux-x86_64`
 - `macos-x86_64`
 - `macos-aarch64`

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,8 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2019-2026 Elias Bachaalany
+# SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
 #
-# Copyright (c) Elias Bachaalany
+# This file is licensed under the Human-Origin Source License v1.0.
+# See LICENSE.
 
 name: build
 
@@ -17,13 +17,25 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Every job installs THIS repository's ida-cmake into its own $IDASDK/ida-cmake
+# directory and builds the templates from there. It never reads or writes the
+# SDK's own cmake tree (IDA SDK 9.4 vendors its own cmake under src/cmake), so
+# the templates are always built with this ida-cmake across every SDK version.
+
 jobs:
   build:
-    name: Build (${{ matrix.os }})
+    name: Build (${{ matrix.os }}, ${{ matrix.sdk }})
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
+        os: [Linux, macOS, Windows]
+        # SDK versions from https://github.com/HexRaysSA/ida-sdk (git tags).
+        # Pin the latest SDK packaging (-sdk.N) per IDA version; 9.4 has only
+        # -release so far. 9.1 is intentionally absent: the repo has no 9.1 tag
+        # (earliest is 9.2). 9.2 still uses the old compiler-named lib layout,
+        # exercising ida-cmake's lib-dir fallback; 9.3/9.4 use the new layout.
+        sdk: [v9.2.0-sdk.1, v9.3.1-sdk.1, v9.4.0-release]
         include:
           - os: Linux
             runner: ubuntu-latest
@@ -32,38 +44,60 @@ jobs:
           - os: Windows
             runner: windows-latest
     env:
-      IDASDK: ${{ github.workspace }}/ida-sdk/src
+      IDASDK: ${{ github.workspace }}/ida-sdk
     steps:
       - name: Checkout ida-cmake
         uses: actions/checkout@v4
 
-      - name: Setup IDA SDK
+      - name: Setup IDA SDK (${{ matrix.sdk }}) with our ida-cmake
         shell: bash
         run: |
-          git clone --depth 1 https://github.com/HexRaysSA/ida-sdk ida-sdk
-          mkdir -p "${IDASDK}/ida-cmake"
-          cp -r bootstrap.cmake idasdkConfig.cmake cmake templates samples "${IDASDK}/ida-cmake/"
+          git clone --branch ${{ matrix.sdk }} --depth 1 https://github.com/HexRaysSA/ida-sdk ida-sdk
+          # Install this repo's ida-cmake into its own $IDASDK/ida-cmake dir
+          # (independent of the SDK's own src/cmake; we never touch that).
+          git clone --local . "${IDASDK}/ida-cmake"
 
       - name: Build all templates
         shell: bash
         run: cmake -P "${IDASDK}/ida-cmake/cmake/ci.cmake"
 
-  # Test macOS universal binary support (Issue #19)
-  macos-universal:
-    name: Build (macOS Universal)
-    runs-on: macos-latest
+  # Windows-on-ARM cross-build. ARM64 Windows libraries exist only in SDK 9.4,
+  # so this job runs a single version and cross-compiles ARM64 on an x64 runner.
+  windows-arm64:
+    name: Build (Windows ARM64 cross, v9.4.0-release)
+    runs-on: windows-latest
     env:
-      IDASDK: ${{ github.workspace }}/ida-sdk/src
+      IDASDK: ${{ github.workspace }}/ida-sdk
+      IDA_CI_ARCH: ARM64
     steps:
       - name: Checkout ida-cmake
         uses: actions/checkout@v4
 
-      - name: Setup IDA SDK
+      - name: Setup IDA SDK 9.4 with our ida-cmake
         shell: bash
         run: |
-          git clone --depth 1 https://github.com/HexRaysSA/ida-sdk ida-sdk
-          mkdir -p "${IDASDK}/ida-cmake"
-          cp -r bootstrap.cmake idasdkConfig.cmake cmake templates samples "${IDASDK}/ida-cmake/"
+          git clone --branch v9.4.0-release --depth 1 https://github.com/HexRaysSA/ida-sdk ida-sdk
+          git clone --local . "${IDASDK}/ida-cmake"
+
+      - name: Cross-build all templates for ARM64
+        shell: bash
+        run: cmake -P "${IDASDK}/ida-cmake/cmake/ci.cmake"
+
+  # macOS universal binary support (Issue #19).
+  macos-universal:
+    name: Build (macOS Universal, v9.4.0-release)
+    runs-on: macos-latest
+    env:
+      IDASDK: ${{ github.workspace }}/ida-sdk
+    steps:
+      - name: Checkout ida-cmake
+        uses: actions/checkout@v4
+
+      - name: Setup IDA SDK 9.4 with our ida-cmake
+        shell: bash
+        run: |
+          git clone --branch v9.4.0-release --depth 1 https://github.com/HexRaysSA/ida-sdk ida-sdk
+          git clone --local . "${IDASDK}/ida-cmake"
 
       - name: Build plugin template (universal binary)
         shell: bash
@@ -75,11 +109,10 @@ jobs:
       - name: Verify universal binary
         shell: bash
         run: |
-          # Plugin is deployed to $IDASDK/bin/plugins/ (default IDABIN)
-          PLUGIN="${IDASDK}/bin/plugins/myplugin.dylib"
+          # Plugin deploys to <resolved IDASDK>/bin/plugins (default IDABIN)
+          PLUGIN="${IDASDK}/src/bin/plugins/myplugin.dylib"
           echo "Checking plugin: $PLUGIN"
           lipo -info "$PLUGIN"
-          # Verify it contains both architectures
           lipo -info "$PLUGIN" | grep -q "arm64" || (echo "Missing arm64!" && exit 1)
           lipo -info "$PLUGIN" | grep -q "x86_64" || (echo "Missing x86_64!" && exit 1)
           echo "Plugin universal binary verified successfully!"

--- a/LICENSE
+++ b/LICENSE
@@ -1,374 +1,693 @@
-Mozilla Public License Version 2.0
-==================================
+Human-Origin Source License v1.0
+=================================================
+
+This is a source-available license for any first-party work that expressly
+identifies this license.
+
+This license is derived in structure from the Mozilla Public License 2.0, but
+it is not the Mozilla Public License, it is not MPL-only, and it is not a
+standard OSI-approved open-source license. The added terms below are part of
+the license grant. They are intended to preserve human attribution, prevent
+erasure of origin, and prohibit unauthorized private derivation, cloning,
+rebranding, porting, and AI-assisted implementation mining.
+
+The Mozilla Foundation does not maintain, endorse, or approve this license.
+
+Quick Summary (Non-Normative)
+-----------------------------
+
+This summary is explanatory, illustrative, and non-exhaustive. It does not
+expand or narrow the operative license terms below. The license text below
+governs.
+
+You may generally, subject to the full license terms:
+
+    - read, inspect, build, run, evaluate, and benchmark the Covered Software;
+    - study the Covered Software for understanding, provided it is not used as
+      an implementation source for a Derivative Implementation;
+    - use the Covered Software unchanged as a dependency, including
+      commercially;
+    - distribute unmodified copies, including through package managers and
+      similar distribution channels;
+    - include unmodified Covered Software in larger proprietary, commercial,
+      internal, or personal software; and
+    - prepare and submit bug fixes, optimizations, features, documentation,
+      tests, and pull requests back to the upstream Project.
+
+You may not, without prior written permission from the Author:
+
+    - ship or maintain a modified version outside the contribution-purpose
+      rules;
+    - maintain a divergent private or internal fork;
+    - port, clone, rebrand, or recreate the Covered Software;
+    - create an API-compatible replacement, behavioral clone, competing
+      implementation, or Derivative Implementation; or
+    - use AI-assisted implementation mining to create, improve, test,
+      document, or validate a Derivative Implementation.
+
+0. Purpose
+----------
+
+This license allows the public to inspect, build, evaluate, distribute, and use
+unmodified copies of the Covered Software, including as a dependency in larger
+software systems, subject to the conditions below.
+
+It does not grant permission to silently maintain divergent modifications or
+forks, port, rebrand, clone, or mine the Covered Software as an implementation
+source, whether manually or with AI systems, without prior written permission
+from the Author.
+
+The purpose is simple: reuse is allowed only on terms that preserve the human
+origin and provenance of the work. Access is not permission to conceal,
+materially obscure, or misrepresent the origin of the Covered Software, or to
+turn the project into a ready-made source for a Derivative Implementation.
+
+"Human-Origin" does not mean that the Covered Software was created without
+tools, automation, or AI assistance. It means that the Covered Software is
+published under the stewardship, judgment, authorship responsibility,
+integration effort, and maintenance of its human author, and that this human
+origin must not be erased.
+
+0.1. Copyright and Contract
+
+This license grants contractual permissions in addition to permissions that may
+exist under applicable copyright law. Nothing in this license claims ownership
+over abstract ideas, facts, general programming techniques, or independently created implementations that are not copied
+from, materially derived from, or Substantially Informed By the Covered
+Software.
 
 1. Definitions
 --------------
 
-1.1. "Contributor"
-    means each individual or legal entity that creates, contributes to
-    the creation of, or owns Covered Software.
+1.1. "Author"
+    means the person or legal entity identified in the Covered Software's
+    project documentation, source notices, repository metadata, package
+    metadata, copyright notices, or other official Project materials as the
+    copyright holder, licensor, author, maintainer, or project steward for the
+    Project. If multiple Authors are identified, "Author" means each such person
+    or legal entity with respect to the rights that person or entity owns or
+    controls.
 
-1.2. "Contributor Version"
-    means the combination of the Contributions of others (if any) used
-    by a Contributor and that particular Contributor's Contribution.
+1.2. "Project"
+    means the first-party software project, repository, package, component, or
+    other work that expressly identifies this license and includes the Covered
+    Software.
 
-1.3. "Contribution"
-    means Covered Software of a particular Contributor.
+1.3. "Permission Contact"
+    means the email address, issue tracker, form, repository link, or other
+    written contact path identified in the Project's documentation, repository
+    metadata, package metadata, or other official Project materials for
+    permission requests under this license. If no specific permission-request
+    contact is identified, the Permission Contact is the ordinary written
+    contact path for the Author or Project.
 
-1.4. "Covered Software"
-    means Source Code Form to which the initial Contributor has attached
-    the notice in Exhibit A, the Executable Form of such Source Code
-    Form, and Modifications of such Source Code Form, in each case
-    including portions thereof.
+1.4. "Upstream Project URL"
+    means the URL, repository location, package page, documentation page, or
+    other durable identifier identified by the Project's official materials as
+    the upstream location for the Covered Software.
 
-1.5. "Incompatible With Secondary Licenses"
-    means
+1.5. "Contributor"
+    means the Author and any individual or legal entity that intentionally
+    submits a Contribution to the Covered Software.
 
-    (a) that the initial Contributor has attached the notice described
-        in Exhibit B to the Covered Software; or
+1.6. "Contribution"
+    means any original work of authorship, code, documentation, example,
+    patch, build file, design note, or other material intentionally submitted
+    for inclusion in the Covered Software.
 
-    (b) that the Covered Software was made available under the terms of
-        version 1.1 or earlier of the License, but not also under the
-        terms of a Secondary License.
+1.7. "Covered Software"
+    means Source Code Form to which the Author or a Contributor has attached a
+    notice identifying this license, the Executable Form of that Source Code
+    Form, and any portion of either.
 
-1.6. "Executable Form"
-    means any form of the work other than Source Code Form.
+1.8. "Source Code Form"
+    means the form of the work preferred for making modifications, including
+    source files, headers, scripts, examples, documentation, build files, and
+    associated project metadata that are first-party project material.
 
-1.7. "Larger Work"
-    means a work that combines Covered Software with other material, in
-    a separate file or files, that is not Covered Software.
+1.9. "Executable Form"
+    means any form of the Covered Software other than Source Code Form,
+    including object code, static libraries, dynamic libraries, binaries,
+    archives, and packaged distributions.
 
-1.8. "License"
-    means this document.
+1.10. "Unmodified Dependency Use"
+    means using, linking, compiling, packaging, or distributing an unmodified
+    copy of the Covered Software as a dependency of a Larger Work. Build flags,
+    compiler options, generated build artifacts, and external build-system
+    integration do not by themselves make the Covered Software modified.
 
-1.9. "Licensable"
-    means having the right to grant, to the maximum extent possible,
-    whether at the time of the initial grant or subsequently, any and
-    all of the rights conveyed by this License.
+1.11. "Modification"
+    means any change, addition, deletion, adaptation, translation, port,
+    refactor, restructuring, transformation, patch, or other alteration of the
+    Covered Software in Source Code Form, whether or not distributed.
 
-1.10. "Modifications"
-    means any of the following:
+1.12. "Contribution-Purpose Modification"
+    means a Modification made in good faith solely to fix a bug, improve
+    compatibility, optimize performance, add a feature, improve documentation,
+    prepare a patch, prepare a pull request, discuss a proposed change, or
+    otherwise contribute improvements back to the upstream project maintained by
+    the Author. A Contribution-Purpose Modification does not include a
+    divergent private fork, competing product, API-compatible replacement,
+    rebrand, port, clone, or Substantially Similar Implementation.
 
-    (a) any file in Source Code Form that results from an addition to,
-        deletion from, or modification of the contents of Covered
-        Software; or
+1.13. "Substantially Similar Implementation"
+    means an implementation that reproduces a substantial portion of the
+    structure, organization, API relationships, algorithms, interoperability
+    design, implementation techniques, or expressive implementation decisions of
+    the Covered Software, rather than merely implementing similar abstract
+    functionality.
 
-    (b) any new file in Source Code Form that contains any Covered
-        Software.
+1.14. "Derivative Implementation"
+    means any implementation, library, module, service, binding, port, fork,
+    rebrand, wrapper, API-compatible replacement, behavioral clone, or
+    Substantially Similar Implementation that is copied from, adapted from,
+    materially derived from, or Substantially Informed By the Covered Software,
+    including its implementation expression, structure, organization, API
+    relationships, examples, documentation, design, debugging decisions, or
+    other protected expression.
 
-1.11. "Patent Claims" of a Contributor
-    means any patent claim(s), including without limitation, method,
-    process, and apparatus claims, in any patent Licensable by such
-    Contributor that would be infringed, but for the grant of the
-    License, by the making, using, selling, offering for sale, having
-    made, import, or transfer of either its Contributions or its
-    Contributor Version.
+1.15. "Substantially Informed By"
+    means, when used with respect to the Covered Software, that a person or AI
+    System had access to the Covered Software and materially relied on protected
+    implementation expression from the Covered Software when creating,
+    improving, testing, documenting, or validating another implementation. Mere
+    knowledge of the Covered Software, high-level inspiration, compatibility
+    goals, use of public behavior, use of independently known concepts, or access without material reliance on protected implementation
+    expression is not Substantially Informed By.
 
-1.12. "Secondary License"
-    means either the GNU General Public License, Version 2.0, the GNU
-    Lesser General Public License, Version 2.1, the GNU Affero General
-    Public License, Version 3.0, or any later versions of those
-    licenses.
+1.16. "Independent Development"
+    means software created without copying from, materially deriving from, or
+    being Substantially Informed By the Covered Software.
 
-1.13. "Source Code Form"
-    means the form of the work preferred for making modifications.
+1.17. "Larger Work"
+    means a work that combines unmodified Covered Software with other material
+    in a separate file or files, where the other material is not Covered
+    Software and is not a Derivative Implementation.
 
-1.14. "You" (or "Your")
-    means an individual or a legal entity exercising rights under this
-    License. For legal entities, "You" includes any entity that
-    controls, is controlled by, or is under common control with You. For
-    purposes of this definition, "control" means (a) the power, direct
-    or indirect, to cause the direction or management of such entity,
-    whether by contract or otherwise, or (b) ownership of more than
-    fifty percent (50%) of the outstanding shares or beneficial
-    ownership of such entity.
+1.18. "AI System"
+    means a machine-learning system, large language model, code-generation
+    model, agentic coding system, retrieval-augmented generation system,
+    automated programming assistant, fine-tuned model, training pipeline,
+    evaluation pipeline, dataset-building pipeline, or materially similar
+    automated system.
 
-2. License Grants and Conditions
---------------------------------
+1.19. "AI-Assisted Implementation Mining"
+    means using the Covered Software, or any substantial portion of its source,
+    examples, documentation, architecture, APIs, design, debugging decisions,
+    or commit history, as input, context, retrieval material, training data,
+    fine-tuning data, evaluation data, prompt material, or agent instructions
+    for the purpose of creating, improving, testing, documenting, or validating
+    a Derivative Implementation.
 
-2.1. Grants
+1.20. "Human-Origin Attribution"
+    means visible attribution to the Author and project origin, in substantially
+    this form:
 
-Each Contributor hereby grants You a world-wide, royalty-free,
-non-exclusive license:
+        This project includes code or implementation work derived from or
+        substantially informed by [PROJECT NAME] by [AUTHOR NAME]:
+        [UPSTREAM PROJECT URL]
 
-(a) under intellectual property rights (other than patent or trademark)
-    Licensable by such Contributor to use, reproduce, make available,
-    modify, display, perform, distribute, and otherwise exploit its
-    Contributions, either on an unmodified basis, with Modifications, or
-    as part of a Larger Work; and
+1.21. "Licensable"
+    means having the right to grant, to the maximum extent possible, whether at
+    the time of the initial grant or subsequently, the rights conveyed by this
+    license.
 
-(b) under Patent Claims of such Contributor to make, use, sell, offer
-    for sale, have made, import, and otherwise transfer either its
-    Contributions or its Contributor Version.
+1.22. "Patent Claims" of a Contributor
+    means any patent claim, including without limitation method, process, and
+    apparatus claims, in any patent Licensable by that Contributor that would be
+    infringed, but for the grant of this license, by the making, using, selling,
+    offering for sale, having made, importing, or transferring of that
+    Contributor's Contributions as permitted by this license.
 
-2.2. Effective Date
+2. License Grants
+-----------------
 
-The licenses granted in Section 2.1 with respect to any Contribution
-become effective for each Contribution on the date the Contributor first
-distributes such Contribution.
+Subject to Your compliance with this license, each Contributor grants You a
+worldwide, royalty-free, non-exclusive license:
 
-2.3. Limitations on Grant Scope
+2.1. Copyright Grant
+    to read, inspect, build, run, reproduce, make available, distribute, and
+    otherwise use unmodified copies of that Contributor's Contributions, either
+    alone or as part of Unmodified Dependency Use in a Larger Work, and to
+    create, test, publish, and distribute Contribution-Purpose Modifications as
+    permitted by Section 2.4.
 
-The licenses granted in this Section 2 are the only rights granted under
-this License. No additional rights or licenses will be implied from the
-distribution or licensing of Covered Software under this License.
-Notwithstanding Section 2.1(b) above, no patent license is granted by a
-Contributor:
+2.2. Patent Grant
+    under Patent Claims of that Contributor to make, use, sell, offer for sale,
+    have made, import, and otherwise transfer unmodified copies of that
+    Contributor's Contributions, either alone or as part of Unmodified
+    Dependency Use in a Larger Work, and to create, use, test, publish, and
+    distribute Contribution-Purpose Modifications solely as permitted by
+    Section 2.4, but only to the extent those Patent Claims would be infringed
+    by that Contributor's Contributions themselves as used in those
+    Contribution-Purpose Modifications. This patent grant does not cover claims
+    infringed only by Your changes, third-party changes, or combinations with
+    other software.
 
-(a) for any code that a Contributor has removed from Covered Software;
-    or
+2.3. No Implied Rights
+    The licenses granted in this Section are the only rights granted under this
+    license. No additional rights or licenses are implied. No trademark,
+    service mark, trade name, logo, endorsement, publicity, or moral-rights
+    waiver is granted except as necessary to provide required attribution and
+    notices.
 
-(b) for infringements caused by: (i) Your and any other third party's
-    modifications of Covered Software, or (ii) the combination of its
-    Contributions with other software (except as part of its Contributor
-    Version); or
+2.4. Contribution-Purpose Modifications
+    You may create, use, test, reproduce, publish, and distribute
+    Contribution-Purpose Modifications solely to prepare, discuss, submit, or
+    offer improvements back to the upstream project maintained by the Author.
+    This permission includes creating a temporary branch, fork, patch series, or
+    pull request for contribution-back purposes.
 
-(c) under Patent Claims infringed by Covered Software in the absence of
-    its Contributions.
+    To rely on this permission, You must:
 
-This License does not grant any rights in the trademarks, service marks,
-or logos of any Contributor (except as may be necessary to comply with
-the notice requirements in Section 3.4).
+    (a) preserve all notices required by this license;
 
-2.4. Subsequent Licenses
+    (b) clearly mark modified files or otherwise make the proposed changes
+        reasonably visible to reviewers;
 
-No Contributor makes additional grants as a result of Your choice to
-distribute the Covered Software under a subsequent version of this
-License (see Section 10.2) or under the terms of a Secondary License (if
-permitted under the terms of Section 3.3).
+    (c) submit or offer the Modification back to the Author in good faith by
+        pull request, patch, issue, email, or other written contribution path
+        within 90 days after completion of the proposed Modification;
 
-2.5. Representation
+    (d) not use the Modification as a divergent private fork, competing product,
+        substitute library, API-compatible replacement, rebrand, port, clone, or
+        Substantially Similar Implementation;
 
-Each Contributor represents that the Contributor believes its
-Contributions are its original creation(s) or it has sufficient rights
-to grant the rights to its Contributions conveyed by this License.
+    (e) not distribute, publish, package, advertise, or make available the
+        Modification as an independent product, independent fork, replacement
+        package, hosted service, or competing implementation; and
 
-2.6. Fair Use
+    (f) not use the Modification for ongoing production, commercial, internal,
+        or operational purposes except for temporary evaluation, testing,
+        debugging, review, or contribution preparation.
 
-This License is not intended to limit any rights You have under
-applicable copyright doctrines of fair use, fair dealing, or other
-equivalents.
+    If the Author declines, rejects, or does not accept a Contribution-Purpose
+    Modification, You may retain the Contribution-Purpose Modification solely
+    for archival, record-keeping, or historical purposes. This public license
+    does not grant You continuing permission to use it operationally, maintain
+    it as a private/internal fork, or distribute it as a divergent
+    implementation. You may request separate written permission under
+    Section 2.6.
 
-2.7. Conditions
+2.5. No License for Other Modifications or Derivative Implementations
+    Except for Contribution-Purpose Modifications permitted by Section 2.4, this
+    license does not grant You permission to create, use, keep, distribute, or
+    make available any Modification or Derivative Implementation, including for
+    private, internal, experimental, or non-public use, without prior written
+    permission from the Author.
 
-Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
-in Section 2.1.
+2.6. Additional Permissions and Separate Licensing
+    If You want to use the Covered Software in a way that is not permitted by
+    this license, You may request additional permission from the Author through
+    the Permission Contact.
 
-3. Responsibilities
--------------------
+    This includes, without limitation, commercial modification, redistribution
+    beyond the public grant, derivative licensing, private/internal modification
+    rights, long-term maintenance forks, ports, Derivative Implementations,
+    API-compatible replacements, rebrands, competing
+    implementations, AI-assisted implementation mining, or other uses outside
+    the public license grant.
 
-3.1. Distribution of Source Form
+    Permission requests should be made through the Permission Contact.
 
-All distribution of Covered Software in Source Code Form, including any
-Modifications that You create or to which You contribute, must be under
-the terms of this License. You must inform recipients that the Source
-Code Form of the Covered Software is governed by the terms of this
-License, and how they can obtain a copy of this License. You may not
-attempt to alter or restrict the recipients' rights in the Source Code
-Form.
+    The Author may grant additional permission subject to reasonable negotiated
+    conditions, including attribution, source disclosure, contribution-back
+    obligations, licensing fees, usage limits, or other terms.
 
-3.2. Distribution of Executable Form
+    Any additional permission, exception, commercial license, private license,
+    or separate agreement must be granted in writing by the Author or an
+    authorized representative of the Author. No additional permission is implied
+    by discussion, silence, availability of source code, repository access,
+    issue comments, pull requests, or prior dealings.
 
-If You distribute Covered Software in Executable Form then:
+    Contributors do not receive authority to grant additional permissions,
+    exceptions, private licenses, or derivative-use rights merely by submitting
+    Contributions unless the Author separately authorizes them in writing.
 
-(a) such Covered Software must also be made available in Source Code
-    Form, as described in Section 3.1, and You must inform recipients of
-    the Executable Form how they can obtain a copy of such Source Code
-    Form by reasonable means in a timely manner, at a charge no more
-    than the cost of distribution to the recipient; and
+3. Conditions for All Permitted Use
+-----------------------------------
 
-(b) You may distribute such Executable Form under the terms of this
-    License, or sublicense it under different terms, provided that the
-    license for the Executable Form does not attempt to limit or alter
-    the recipients' rights in the Source Code Form under this License.
+The grants in Section 2 are conditioned on all of the following:
 
-3.3. Distribution of a Larger Work
+3.1. Preserve Notices
+    You must not remove, obscure, rename away, or alter the substance of any
+    copyright notice, license notice, SPDX identifier, author notice,
+    attribution notice, patent notice, warranty disclaimer, limitation of
+    liability, or source-origin notice contained in the Covered Software,
+    except to correct a known factual inaccuracy.
 
-You may create and distribute a Larger Work under terms of Your choice,
-provided that You also comply with the requirements of this License for
-the Covered Software. If the Larger Work is a combination of Covered
-Software with a work governed by one or more Secondary Licenses, and the
-Covered Software is not Incompatible With Secondary Licenses, this
-License permits You to additionally distribute such Covered Software
-under the terms of such Secondary License(s), so that the recipient of
-the Larger Work may, at their option, further distribute the Covered
-Software under the terms of either this License or such Secondary
-License(s).
+3.2. Provide the License
+    Any distribution of the Covered Software in Source Code Form or Executable
+    Form must include a complete copy of this license, or a durable, public,
+    and reasonably direct link to the exact license text that applies to the
+    distributed version.
 
-3.4. Notices
+3.3. Source Availability for Covered Software
+    If You distribute the Covered Software in Executable Form, including as a
+    static library, dynamic library, object file, or packaged dependency, You
+    must make the corresponding unmodified Source Code Form of the Covered
+    Software available by reasonable means. A durable public link to the
+    upstream repository and exact version is sufficient for unmodified copies.
 
-You may not remove or alter the substance of any license notices
-(including copyright notices, patent notices, disclaimers of warranty,
-or limitations of liability) contained within the Source Code Form of
-the Covered Software, except that You may alter any license notices to
-the extent required to remedy known factual inaccuracies.
+3.4. Package Managers and Distribution Channels
+    You may distribute unmodified Covered Software through package managers,
+    Linux or operating-system distributions, Docker or container images, vcpkg,
+    Conan, Homebrew, NuGet, and similar distribution systems, provided that You
+    preserve required notices, provide or link to this license, and make the
+    corresponding unmodified Source Code Form available as required by this
+    license.
 
-3.5. Application of Additional Terms
+3.5. Larger Works
+    You may license Your own separate files in a Larger Work under terms of
+    Your choice, including proprietary terms, provided that those terms do not
+    limit, obscure, or contradict the rights, restrictions, notices, and
+    attribution requirements that apply to the Covered Software.
 
-You may choose to offer, and to charge a fee for, warranty, support,
-indemnity or liability obligations to one or more recipients of Covered
-Software. However, You may do so only on Your own behalf, and not on
-behalf of any Contributor. You must make it absolutely clear that any
-such warranty, support, indemnity, or liability obligation is offered by
-You alone, and You hereby agree to indemnify every Contributor for any
-liability incurred by such Contributor as a result of warranty, support,
-indemnity or liability terms You offer. You may include additional
-disclaimers of warranty and limitations of liability specific to any
-jurisdiction.
+3.6. No False Independence
+    You must not represent work that is copied from, adapted from, materially
+    derived from, or Substantially Informed By the Covered Software as
+    independently created.
 
-4. Inability to Comply Due to Statute or Regulation
----------------------------------------------------
+3.7. No Implied Endorsement
+    You must not imply that the Author endorses, sponsors, approves, maintains,
+    or collaborates on Your project, product, service, fork, port, derivative,
+    or Larger Work unless the Author has granted that permission in writing.
 
-If it is impossible for You to comply with any of the terms of this
-License with respect to some or all of the Covered Software due to
-statute, judicial order, or regulation then You must: (a) comply with
-the terms of this License to the maximum extent possible; and (b)
-describe the limitations and the code they affect. Such description must
-be placed in a text file included with all distributions of the Covered
-Software under the name "LEGAL", and included in all Covered Software
-distributed in Source Code Form. Except to the extent prohibited by
-statute or regulation, such description must be sufficiently detailed
-for a recipient of ordinary skill to be able to understand it.
+3.8. Benchmarking and Evaluation
+    This license does not prohibit benchmarking, performance comparison,
+    academic evaluation, interoperability testing, or publication of benchmark
+    results, provided that the Covered Software is not used to create, improve,
+    test, document, or validate a Derivative Implementation.
 
-5. Termination
---------------
+4. Human-Origin Attribution and Provenance
+------------------------------------------
 
-5.1. The rights granted under this License will terminate automatically
-if You fail to comply with any of its terms. However, if You become
-compliant, then the rights granted under this License from a particular
-Contributor are reinstated (a) provisionally, unless and until such
-Contributor explicitly and finally terminates Your grants, and (b) on an
-ongoing basis, if such Contributor fails to notify You of the
-non-compliance by some reasonable means prior to 60 days after You have
-come back into compliance. Moreover, Your grants from a particular
-Contributor are reinstated on an ongoing basis if such Contributor
-notifies You of the non-compliance by some reasonable means, this is the
-first time You have received notice of non-compliance with this License
-from such Contributor, and You become compliant prior to 30 days after
-Your receipt of the notice.
+4.1. Attribution for Distributed Use
+    If You distribute the Covered Software, include it in a Larger Work, or make
+    a product or service available that contains or depends on the Covered
+    Software, You must provide visible attribution to the Author and the
+    original project in a README, documentation, third-party notices, or other
+    place where recipients normally review licensing and credits.
 
-5.2. If You initiate litigation against any entity by asserting a patent
-infringement claim (excluding declaratory judgment actions,
-counter-claims, and cross-claims) alleging that a Contributor Version
-directly or indirectly infringes any patent, then the rights granted to
-You by any and all Contributors for the Covered Software under Section
-2.1 of this License shall terminate.
+4.2. Attribution for Derived or Substantially Informed Work
+    If the Covered Software materially informs any distributed work, including a
+    permitted Modification, permitted Derivative Implementation, port, wrapper,
+    API-compatible implementation, Substantially Similar Implementation, public
+    documentation, or public design, You must include Human-Origin Attribution
+    in the README or equivalent project documentation.
 
-5.3. In the event of termination under Sections 5.1 or 5.2 above, all
-end user license agreements (excluding distributors and resellers) which
-have been validly granted by You or Your distributors under this License
-prior to termination shall survive termination.
+4.3. About/Credits UI
+    If the distributed work has an About box, credits screen, acknowledgements
+    page, package metadata page, or comparable user-visible credit surface, You
+    must include attribution to the Author and original project there as well.
 
-************************************************************************
-*                                                                      *
-*  6. Disclaimer of Warranty                                           *
-*  -------------------------                                           *
-*                                                                      *
-*  Covered Software is provided under this License on an "as is"       *
-*  basis, without warranty of any kind, either expressed, implied, or   *
-*  statutory, including, without limitation, warranties that the        *
-*  Covered Software is free of defects, merchantable, fit for a        *
-*  particular purpose or non-infringing. The entire risk as to the      *
-*  quality and performance of the Covered Software is with You.         *
-*  Should any Covered Software prove defective in any respect, You      *
-*  (not any Contributor) assume the cost of any necessary servicing,    *
-*  repair, or correction. This disclaimer of warranty constitutes an    *
-*  essential part of this License. No use of any Covered Software is    *
-*  authorized under this License except under this disclaimer.         *
-*                                                                      *
-************************************************************************
+4.4. Disclosure of Relationship to the Covered Software
+    Where attribution is required, You must state whether Your work is copied
+    from, adapted from, ported from, Substantially Informed By the Covered
+    Software, or AI-assisted using the Covered Software.
 
-************************************************************************
-*                                                                      *
-*  7. Limitation of Liability                                          *
-*  --------------------------                                          *
-*                                                                      *
-*  Under no circumstances and under no legal theory, whether tort       *
-*  (including negligence), contract, or otherwise, shall any            *
-*  Contributor, or anyone who distributes Covered Software as           *
-*  permitted above, be liable to You for any direct, indirect,          *
-*  special, incidental, or consequential damages of any character       *
-*  including, without limitation, damages for lost profits, loss of     *
-*  goodwill, work stoppage, computer failure or malfunction, or any     *
-*  and all other commercial damages or losses, even if such party       *
-*  shall have been informed of the possibility of such damages. This    *
-*  limitation of liability shall not apply to liability for death or    *
-*  personal injury resulting from such party's negligence to the        *
-*  extent applicable law prohibits such limitation. Some                *
-*  jurisdictions do not allow the exclusion or limitation of            *
-*  incidental or consequential damages, so this exclusion and           *
-*  limitation may not apply to You.                                    *
-*                                                                      *
-************************************************************************
+4.5. No Hidden or Misleading Attribution
+    Minimal, hidden, misleading, machine-only, or source-header-only credit is
+    not enough when this license requires visible attribution. The attribution
+    must be reasonably discoverable by users, maintainers, reviewers, and
+    recipients without source archaeology.
 
-8. Litigation
--------------
+5. AI and Automated Implementation Mining
+-----------------------------------------
 
-Any litigation relating to this License may be brought only in the
-courts of a jurisdiction where the defendant maintains its principal
-place of business and such litigation shall be governed by laws of that
-jurisdiction, without reference to its conflict-of-law provisions.
-Nothing in this Section shall prevent a party's ability to bring
-cross-claims or counter-claims.
+5.1. No AI Cloning Without Permission
+    You may not perform AI-Assisted Implementation Mining without prior written
+    permission from the Author.
 
-9. Miscellaneous
+5.2. Prohibited AI Uses
+    Without prior written permission from the Author, You may not use the
+    Covered Software as AI input, context, retrieval material, prompt material,
+    training data, fine-tuning data, evaluation data, or agent instructions for
+    the purpose of creating, improving, testing, documenting, or validating a
+    Derivative Implementation.
+
+5.3. No Evasion Through Transformation
+    The restriction in this Section applies even if the resulting work uses
+    different file names, symbols, namespaces, formatting, language, structure,
+    comments, documentation, branding, or repository history.
+
+5.4. Permitted Non-Clone Automation
+    This Section does not prohibit ordinary search, indexing, security
+    scanning, build analysis, static analysis, code review assistance, patch
+    review assistance, test generation, test review assistance, compiler
+    diagnostic explanation, documentation summarization, AI-generated tests for the Covered Software or
+    Contribution-Purpose Modifications, AI-assisted patch preparation for
+    Contribution-Purpose Modifications permitted by Section 2.4, or use of
+    applications built with unmodified Covered Software to expose unrelated
+    application data to AI agents, provided that such use is not for creating or
+    improving a Derivative Implementation, and is not for porting, rebranding,
+    replacing, or competing with the Covered Software.
+
+6. Manual Cloning, Porting, and Rebranding
+------------------------------------------
+
+6.1. No Manual Clone Without Permission
+    You may not manually copy, adapt, port, rebrand, restructure, or recreate
+    the Covered Software as a Derivative Implementation without prior written
+    permission from the Author.
+
+6.2. Substantial Implementation Influence
+    A work may be a Derivative Implementation even if it is not a literal copy,
+    if the Covered Software materially supplied the implementation structure,
+    API shape, behavior, architecture, examples, debugging path, or other
+    protected expression that made the new work possible. Access to the Covered
+    Software plus material reliance on protected implementation expression is
+    required; mere knowledge, public behavior, compatibility goals, or
+    high-level inspiration is not enough.
+
+6.3. High-Level Inspiration
+    This license does not claim ownership over general ideas, facts, public
+    behavior, abstract concepts, or independently created work. High-level
+    inspiration from public descriptions is not prohibited by itself. The
+    restricted boundary is implementation-level copying, adaptation, porting,
+    rebranding, cloning, or substantial implementation derivation.
+
+6.4. Independent Development
+    Nothing in this license prohibits Independent Development. Software that was
+    not copied from, materially derived from, or Substantially Informed By the
+    Covered Software is outside the Derivative Implementation restrictions of
+    this license.
+
+7. Contributions
 ----------------
 
-This License represents the complete agreement concerning the subject
-matter hereof. If any provision of this License is held to be
-unenforceable, such provision shall be reformed only to the extent
-necessary to make it enforceable. Any law or regulation which provides
-that the language of a contract shall be construed against the drafter
-shall not be used to construe this License against a Contributor.
+7.1. Inbound License
+    By intentionally submitting a Contribution to the Covered Software, You
+    agree that the Contribution is licensed under this license unless the
+    Author agrees in writing to different terms.
 
-10. Versions of the License
+7.2. Representation
+    You represent that Your Contribution is Your original creation or that You
+    have sufficient rights to license it under this license.
+
+7.3. No Inconsistent Contributions
+    You must not submit material that is subject to terms inconsistent with this
+    license unless You clearly disclose those terms and the Author accepts them
+    in writing.
+
+8. Third-Party Materials
+------------------------
+
+This license applies only to Covered Software that identifies this license.
+Third-party dependencies, vendored libraries, public-domain components, and
+separately licensed files remain under their own licenses and notices. Nothing
+in this license attempts to relicense third-party material.
+
+9. Prior Versions
+-----------------
+
+This license does not alter rights already granted for prior versions of the
+Covered Software that were distributed under a different license. Those prior
+copies remain governed by the license terms under which recipients received
+them. This license governs Covered Software versions and files that identify
+this license.
+
+10. Termination
+---------------
+
+10.1. Immediate Breach and Termination
+    Except as provided in Section 10.2, if You fail to comply with any term of
+    this license, You are in immediate breach and all rights granted to You
+    under this license terminate automatically and immediately.
+
+10.2. Limited Cure for Accidental Notice and Packaging Breaches
+    If Your only breach is an accidental failure to preserve required notices,
+    include required license text, satisfy source-availability conditions for
+    permitted redistribution, or include required attribution in packaging or
+    documentation, termination will not take effect if You cure the breach
+    within 30 days after receiving written notice from the Author.
+
+    This cure period does not apply to cloning, AI-assisted implementation
+    mining, unauthorized Modifications, Derivative Implementations, divergent
+    forks, ports, rebrands, competing implementations, willful concealment,
+    plagiarism, or provenance misrepresentation. For those violations,
+    termination remains automatic and immediate under Section 10.1.
+
+    The Author may, at the Author's sole discretion, reinstate Your rights or
+    grant additional permission only in writing.
+
+10.3. Survival
+    Sections concerning attribution, provenance, AI restrictions, manual
+    cloning, no implied endorsement, warranty disclaimer, limitation of
+    liability, enforcement, and miscellaneous terms survive termination to the
+    maximum extent permitted by law.
+
+11. Disclaimer of Warranty
+--------------------------
+
+Covered Software is provided under this license on an "as is" basis, without
+warranty of any kind, either express, implied, or statutory, including without
+limitation warranties that the Covered Software is free of defects,
+merchantable, fit for a particular purpose, or non-infringing. The entire risk
+as to the quality and performance of the Covered Software is with You. Should
+any Covered Software prove defective in any respect, You assume the cost of any
+necessary servicing, repair, or correction. No use of any Covered Software is
+authorized under this license except under this disclaimer.
+
+12. Limitation of Liability
 ---------------------------
 
-10.1. New Versions
+Under no circumstances and under no legal theory, whether tort, contract, or
+otherwise, shall any Contributor or distributor of Covered Software be liable to
+You for any direct, indirect, special, incidental, consequential, exemplary, or
+punitive damages of any character, including without limitation damages for lost
+profits, loss of goodwill, work stoppage, computer failure or malfunction, data
+loss, business interruption, or commercial damages or losses, even if such party
+has been informed of the possibility of such damages. This limitation applies
+to the maximum extent permitted by law.
 
-Mozilla Foundation is the license steward. Except as provided in Section
-10.3, no one other than the license steward has the right to modify or
-publish new versions of this License. Each version will be given a
-distinguishing version number.
+13. Enforcement and Forum
+-------------------------
 
-10.2. Effect of New Versions
+13.1. Court of Competent Jurisdiction
+    The Author may enforce this license in any court of competent jurisdiction.
+    Nothing in this license limits the Author's ability to seek injunctive
+    relief, damages, declaratory relief, or any other remedy available under
+    applicable law.
 
-You may distribute the Covered Software under the terms of the version
-of the License under which You originally received the Covered Software,
-or under the terms of any subsequent version published by the license
-steward.
+13.2. Jurisdictional Contacts
+    You agree that making available, distributing, using, cloning, modifying,
+    mining, or deriving from the Covered Software in a jurisdiction may create
+    sufficient contacts for a court in that jurisdiction to hear claims related
+    to this license, to the maximum extent permitted by law.
 
-10.3. Modified Versions
+14. Miscellaneous
+-----------------
 
-If you create software not governed by this License, and you want to
-create a new license for such software, you may create and use a
-modified version of this License if you rename the license and remove
-any references to the name of the license steward (except to note that
-such modified license differs from this License).
+14.1. Severability
+    If any provision of this license is held unenforceable, that provision
+    shall be reformed only to the extent necessary to make it enforceable, and
+    the remaining provisions shall remain in effect.
 
-10.4. Distributing Source Code Form that is Incompatible With Secondary
-Licenses
+14.2. No Waiver
+    Failure by the Author or any Contributor to enforce any provision of this
+    license is not a waiver of the right to enforce that provision later.
 
-If You choose to distribute Source Code Form that is Incompatible With
-Secondary Licenses under the terms of this version of the License, the
-notice described in Exhibit B of this License must be attached.
+14.3. Complete Terms
+    This license represents the complete public license terms for Covered
+    Software that identifies this license. No permission beyond this license is
+    granted unless the Author grants it in writing.
 
-Exhibit A - Source Code Form License Notice
--------------------------------------------
+14.4. License Versions
+    The Author may publish revised versions of this license. You may use the
+    Covered Software only under the version of this license identified in the
+    applicable Source Code Form or under a later version if the Author expressly
+    permits that later version for the Covered Software.
 
-  This Source Code Form is subject to the terms of the Mozilla Public
-  License, v. 2.0. If a copy of the MPL was not distributed with this
-  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+15. Examples and FAQ
+--------------------
 
-If it is not possible or desirable to put the notice in a particular
-file, then You may include the notice in a location (such as a LICENSE
-file in a relevant directory) where a recipient would be likely to look
-for such a notice.
+This Section is explanatory guidance. It is intended to help interpret the
+license, but it does not expand or narrow the operative terms above. The
+examples below are illustrative and non-exhaustive. Similar conduct should be
+interpreted consistently with the operative provisions above.
 
-You may add additional accurate notices of copyright ownership.
+15.1. Examples of Generally Permitted Uses
 
-Exhibit B - "Incompatible With Secondary Licenses" Notice
----------------------------------------------------------
+    You may generally do the following, subject to the full license terms:
 
-  This Source Code Form is "Incompatible With Secondary Licenses", as
-  defined by the Mozilla Public License, v. 2.0.
+    (a) read, inspect, build, and evaluate the Covered Software;
+
+    (b) use unmodified Covered Software as a dependency in personal,
+        commercial, proprietary, or internal software;
+
+    (c) distribute unmodified Covered Software through package managers,
+        operating-system distributions, Docker or container images, vcpkg,
+        Conan, Homebrew, NuGet, or similar distribution systems;
+
+    (d) benchmark the Covered Software, compare performance, conduct academic
+        evaluation, test interoperability, and publish benchmark results;
+
+    (e) fork, branch, patch, or modify the Covered Software to prepare bug
+        fixes, optimizations, features, documentation improvements, tests, or
+        pull requests for contribution back to the upstream project;
+
+    (f) use ordinary development tools, search, indexing, static analysis,
+        security scanning, code review assistance, patch review assistance,
+        test generation, test review assistance, compiler diagnostic
+        explanation, documentation summarization,
+        AI-generated tests for the Covered Software or Contribution-Purpose
+        Modifications, and AI-assisted patch preparation for
+        Contribution-Purpose Modifications; and
+
+    (g) report bugs, propose changes, submit issues, submit patches, and submit
+        pull requests.
+
+15.2. Examples of Uses Requiring Prior Written Permission
+
+    The following uses are not granted by this public license and require prior
+    written permission from the Author:
+
+    (a) maintaining a divergent private or internal fork for operational,
+        production, commercial, or long-term use;
+
+    (b) publishing or maintaining an independent fork as a replacement project;
+
+    (c) porting the Covered Software to another programming language;
+
+    (d) creating an API-compatible replacement, behavioral clone, or competing
+        implementation;
+
+    (e) rebranding the Covered Software or a Derivative Implementation as a
+        separate product or project;
+
+    (f) using an AI System to rewrite, port, clone, rebrand, or recreate the
+        Covered Software as a Derivative Implementation; and
+
+    (g) using the Covered Software as implementation input to create or improve
+        a Derivative Implementation.
+
+15.3. Examples of Uses Outside the Restricted Boundary
+
+    The following are not restricted merely because they are similar at a high
+    level:
+
+    (a) independently creating software that provides similar abstract functionality without copying from, materially deriving
+        from, or being Substantially Informed By the Covered Software;
+
+    (b) learning general programming ideas, or public behavior
+        from documentation without using the Covered Software as an
+        implementation source; and
+
+    (c) using software built with unmodified Covered Software to expose
+        unrelated application data to AI agents.
+
+16. Source Code Form License Notice
+-----------------------------------
+
+Recommended SPDX notice for source files:
+
+    SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
+
+Recommended file header:
+
+    Copyright (c) [YEAR(S)] [AUTHOR NAME]
+    SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
+
+    This file is licensed under the Human-Origin Source License v1.0.
+    See LICENSE.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ CMake build system for developing IDA Pro addons (plugins, loaders, processor mo
 
 >For IDA 9.1 and below, please check the [9.1](https://github.com/allthingsida/ida-cmake/tree/9.1) branch.
 
+> **Relationship to the IDA SDK's bundled CMake.** Since IDA SDK 9.4, the SDK ships its own CMake layout (under the SDK's `cmake/` folder) that is *based on* ida-cmake — see the SDK's `cmake/ACKNOWLEDGMENTS.md`, which credits this project. ida-cmake is independent and self-contained: it does not use, require, or depend on the SDK's bundled copy. Install ida-cmake in its own `$IDASDK/ida-cmake` directory and it drives the build entirely on its own.
+
 ## Two Ways to Use ida-cmake
 
 ida-cmake provides **two approaches** for building IDA addons:
@@ -20,8 +22,15 @@ Both approaches are fully supported. Choose based on your preference!
 ### 1. Prerequisites
 
 - CMake 3.27 or later
-- IDA SDK 9.2+ (set `IDASDK` environment variable)
+- IDA SDK 9.2, 9.3, or 9.4 (set `IDASDK` environment variable, or pass `-DIDASDK=<path>` per build)
 - Visual Studio 2022 (Windows) / GCC/Clang (Linux/macOS)
+
+> **Selecting an SDK per build:** `-DIDASDK=<path>` takes precedence over the `IDASDK`
+> environment variable, so you can build against an alternate SDK (e.g. a 9.4 working
+> copy) without changing your global environment:
+> ```bash
+> cmake -B build -DIDASDK=/path/to/idasdk94
+> ```
 
 ### 2. Setup
 
@@ -376,6 +385,27 @@ cmake -B build -DCMAKE_OSX_ARCHITECTURES=arm64  # or x86_64
 ```
 
 **Technical details:** The IDA SDK provides architecture-specific libraries (`lib/arm64_mac_clang_64/libida.dylib` and `lib/x64_mac_clang_64/libida.dylib`). ida-cmake uses `lipo` to merge these into universal libraries stored in `build/ida-universal-libs/`, which are then linked to your addon.
+
+### Windows on ARM (ARM64)
+
+Windows ARM64 addons are supported and require **IDA SDK 9.4 or later** (earlier SDKs
+do not ship Windows ARM64 import libraries, `lib/arm64_win_64/`).
+
+**Cross-compiling on an x64 host** (Visual Studio's ARM64 toolchain, installable via the
+VS Installer):
+
+```bash
+cmake -B build-arm64 -A ARM64 -DIDASDK=/path/to/idasdk94
+cmake --build build-arm64 --config Release
+```
+
+ida-cmake detects the ARM64 target from `-A ARM64` (or a native ARM64 host) and links
+against the SDK's `arm64_win_64` libraries automatically.
+
+**Deployment when cross-compiling:** to avoid installing an ARM64 binary into an x64 IDA
+(where it could not load), cross-built addons are **not** auto-deployed — they are written
+to `<build>/ida-addons/<arch>/` instead. Force deployment (e.g. when `IDABIN` points at a
+matching ARM64 IDA) with `-DIDA_FORCE_DEPLOY=ON`. Native builds deploy as usual.
 
 ## Examples
 

--- a/bootstrap.cmake
+++ b/bootstrap.cmake
@@ -1,36 +1,45 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2019-2026 Elias Bachaalany
+# SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
 #
-# Copyright (c) Elias Bachaalany
+# This file is licensed under the Human-Origin Source License v1.0.
+# See LICENSE.
 
 # IDA SDK CMake Bootstrap
 # This file sets up the CMAKE_PREFIX_PATH and MODULE_PATH to find the IDASDK package
-# Usage: include($ENV{IDASDK}/src/cmake/bootstrap.cmake)
+# Usage: include($ENV{IDASDK}/ida-cmake/bootstrap.cmake)
 
-if(NOT DEFINED ENV{IDASDK})
-    message(FATAL_ERROR "IDASDK environment variable not set. Please set it to your IDA SDK directory.")
+# Resolve the SDK root. A -DIDASDK=<path> cache variable takes precedence over
+# the IDASDK environment variable, so an alternate SDK (e.g. a 9.4 working copy)
+# can be selected per build without changing the global environment.
+if(DEFINED IDASDK AND NOT IDASDK STREQUAL "")
+    set(_IDASDK_ROOT "${IDASDK}")
+elseif(DEFINED ENV{IDASDK})
+    set(_IDASDK_ROOT "$ENV{IDASDK}")
+else()
+    message(FATAL_ERROR "IDASDK not set. Pass -DIDASDK=<path> or set the IDASDK environment variable to your IDA SDK directory.")
 endif()
 
-# Validate IDASDK path exists and contains expected files
-if(NOT EXISTS "$ENV{IDASDK}")
-    message(FATAL_ERROR "IDASDK path does not exist: $ENV{IDASDK}")
+# Validate the SDK path exists
+if(NOT EXISTS "${_IDASDK_ROOT}")
+    message(FATAL_ERROR "IDASDK path does not exist: ${_IDASDK_ROOT}")
 endif()
 
 # Auto-detect SDK structure: GitHub clone has files under src/, zip distribution at root
-set(_IDASDK_ACTUAL "$ENV{IDASDK}")
+set(_IDASDK_ACTUAL "${_IDASDK_ROOT}")
 if(NOT EXISTS "${_IDASDK_ACTUAL}/include/pro.h")
     # Check if this is a GitHub clone with src/ subdirectory
     if(EXISTS "${_IDASDK_ACTUAL}/src/include/pro.h")
         set(_IDASDK_ACTUAL "${_IDASDK_ACTUAL}/src")
         message(STATUS "Detected GitHub SDK structure, using: ${_IDASDK_ACTUAL}")
     else()
-        message(FATAL_ERROR "Invalid IDASDK directory (missing include/pro.h): $ENV{IDASDK}")
+        message(FATAL_ERROR "Invalid IDASDK directory (missing include/pro.h): ${_IDASDK_ROOT}")
     endif()
 endif()
 
-# Override IDASDK environment variable for this CMake run with the adjusted path
+# Propagate the resolved path via both the environment variable (backward compat)
+# and the IDASDK cache variable, so find_package(idasdk)/idasdkConfig.cmake use it.
 set(ENV{IDASDK} "${_IDASDK_ACTUAL}")
+set(IDASDK "${_IDASDK_ACTUAL}" CACHE PATH "Path to the IDA SDK" FORCE)
 
 # Add ida-cmake to the package search path
 list(APPEND CMAKE_PREFIX_PATH ${CMAKE_CURRENT_LIST_DIR})

--- a/cmake/QtSupport.cmake
+++ b/cmake/QtSupport.cmake
@@ -1,8 +1,8 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2019-2026 Elias Bachaalany
+# SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
 #
-# Copyright (c) Elias Bachaalany
+# This file is licensed under the Human-Origin Source License v1.0.
+# See LICENSE.
 
 # =================================================================
 # Qt Support for IDA SDK

--- a/cmake/agent.cmake
+++ b/cmake/agent.cmake
@@ -1,8 +1,8 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2019-2026 Elias Bachaalany
+# SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
 #
-# Copyright (c) Elias Bachaalany
+# This file is licensed under the Human-Origin Source License v1.0.
+# See LICENSE.
 
 # agent.cmake - Agent installation for ida-cmake
 

--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -1,8 +1,8 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2019-2026 Elias Bachaalany
+# SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
 #
-# Copyright (c) Elias Bachaalany
+# This file is licensed under the Human-Origin Source License v1.0.
+# See LICENSE.
 
 # ci.cmake - Build all ida-cmake templates for CI validation
 # Usage: cmake -P cmake/ci.cmake
@@ -27,10 +27,17 @@ message(STATUS "===========================================")
 message(STATUS "IDA_CMAKE_ROOT: ${IDA_CMAKE_ROOT}")
 message(STATUS "IDASDK: ${IDASDK}")
 
-# Detect generator and build type args
+# Detect generator and build type args. On Windows the target architecture can
+# be overridden via the IDA_CI_ARCH environment variable (x64 or ARM64) to
+# exercise Windows-on-ARM cross-builds; it defaults to x64.
 if(WIN32)
-    set(GENERATOR_ARGS -A x64)
+    set(_CI_ARCH "$ENV{IDA_CI_ARCH}")
+    if(NOT _CI_ARCH)
+        set(_CI_ARCH "x64")
+    endif()
+    set(GENERATOR_ARGS -A ${_CI_ARCH})
     set(BUILD_ARGS --config Release)
+    message(STATUS "Target architecture: ${_CI_ARCH}")
 else()
     set(GENERATOR_ARGS -DCMAKE_BUILD_TYPE=Release)
     set(BUILD_ARGS "")

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -1,8 +1,8 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2019-2026 Elias Bachaalany
+# SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
 #
-# Copyright (c) Elias Bachaalany
+# This file is licensed under the Human-Origin Source License v1.0.
+# See LICENSE.
 
 # compiler.cmake - Compiler configuration for IDA SDK
 
@@ -64,7 +64,7 @@ if(MSVC)
         /wd4146     # unary minus operator applied to unsigned type
     )
 
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")  # GNU, Clang, and AppleClang
     # GCC/Clang specific flags
     target_compile_options(ida_compiler_settings INTERFACE
         -Wall
@@ -80,9 +80,14 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "C
         $<$<CONFIG:Release>:-flto>
     )
 
-    # Linker flags
+    # Linker flags. Dead-code stripping differs per linker: GNU ld uses
+    # --gc-sections, while Apple's ld64 uses -dead_strip (issue #25).
+    if(APPLE)
+        target_link_options(ida_compiler_settings INTERFACE -Wl,-dead_strip)
+    else()
+        target_link_options(ida_compiler_settings INTERFACE -Wl,--gc-sections)
+    endif()
     target_link_options(ida_compiler_settings INTERFACE
-        -Wl,--gc-sections
         $<$<CONFIG:Release>:-flto>
     )
 

--- a/cmake/platform.cmake
+++ b/cmake/platform.cmake
@@ -1,8 +1,8 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2019-2026 Elias Bachaalany
+# SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
 #
-# Copyright (c) Elias Bachaalany
+# This file is licensed under the Human-Origin Source License v1.0.
+# See LICENSE.
 
 # platform.cmake - Platform and OS detection for IDA SDK
 
@@ -12,8 +12,14 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     set(IDA_PLATFORM_NAME "win")
     set(IDAPROPLAT "__NT__")
 
-    # Detect architecture
-    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    # Detect architecture. ARM64 (Windows on ARM) must be detected before the
+    # pointer-size fallback, since ARM64 and x64 both have 8-byte pointers.
+    # With Visual Studio generators, cross-targeting ARM64 is selected via
+    # `-A ARM64`, which sets CMAKE_GENERATOR_PLATFORM (and CMAKE_SYSTEM_PROCESSOR).
+    if(CMAKE_GENERATOR_PLATFORM MATCHES "^(ARM64|arm64)$"
+            OR CMAKE_SYSTEM_PROCESSOR MATCHES "ARM64|aarch64")
+        set(IDA_ARCH "arm64")
+    elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
         set(IDA_ARCH "x64")
     else()
         set(IDA_ARCH "x86")
@@ -134,6 +140,25 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(IDALIB_NAME "libidalib.so")
     set(IDA_SHARED_EXT ".so")
     set(IDA_STATIC_EXT ".a")
+endif()
+
+# Detect cross-compilation (target architecture differs from host). Used to
+# avoid deploying cross-built binaries (e.g. ARM64 addons built on an x64 host)
+# into the host IDA installation, where they would not load.
+string(TOLOWER "${CMAKE_HOST_SYSTEM_PROCESSOR}" _ida_host_proc)
+if(_ida_host_proc MATCHES "arm64|aarch64")
+    set(_ida_host_arch "arm64")
+else()
+    set(_ida_host_arch "x64")
+endif()
+set(_ida_target_arch "${IDA_ARCH}")
+if(_ida_target_arch STREQUAL "x86")
+    set(_ida_target_arch "x64")  # 32-bit shares the x64 host toolchain/dir
+endif()
+if(IDA_ARCH STREQUAL "universal" OR _ida_target_arch STREQUAL _ida_host_arch)
+    set(IDA_IS_CROSS_COMPILE FALSE)
+else()
+    set(IDA_IS_CROSS_COMPILE TRUE)
 endif()
 
 # Output directories for different addon types

--- a/cmake/targets.cmake
+++ b/cmake/targets.cmake
@@ -1,8 +1,8 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2019-2026 Elias Bachaalany
+# SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
 #
-# Copyright (c) Elias Bachaalany
+# This file is licensed under the Human-Origin Source License v1.0.
+# See LICENSE.
 
 # targets.cmake - Target creation functions for IDA SDK addons
 
@@ -23,6 +23,22 @@ if(NOT TARGET ida_addon_base)
     # Note: ida_platform_settings and ida_compiler_settings are linked via IDASDK::* targets
 endif()
 
+# Redirect a deploy directory to a local staging directory when cross-compiling,
+# so cross-built binaries (e.g. ARM64 addons built on an x64 host) are not
+# installed into the host IDA, where they could not load. Opt back in with
+# -DIDA_FORCE_DEPLOY=ON. Returns the effective directory via OUT_VAR.
+function(_ida_apply_cross_deploy_guard OUT_VAR DEPLOY_DIR NAME QUIET)
+    if(IDA_IS_CROSS_COMPILE AND NOT IDA_FORCE_DEPLOY)
+        set(_staging "${CMAKE_BINARY_DIR}/ida-addons/${IDA_ARCH}")
+        if(NOT QUIET)
+            message(STATUS "${NAME}: cross-compiling for ${IDA_ARCH}; skipping deploy, output -> ${_staging} (set -DIDA_FORCE_DEPLOY=ON to deploy anyway)")
+        endif()
+        set(${OUT_VAR} "${_staging}" PARENT_SCOPE)
+    else()
+        set(${OUT_VAR} "${DEPLOY_DIR}" PARENT_SCOPE)
+    endif()
+endfunction()
+
 # Internal function to handle common addon creation logic
 function(_ida_create_addon_internal NAME TYPE SDK_TARGET OUTPUT_DIR)
     cmake_parse_arguments(ARG
@@ -31,6 +47,9 @@ function(_ida_create_addon_internal NAME TYPE SDK_TARGET OUTPUT_DIR)
         "SOURCES;LIBRARIES;INCLUDES;DEFINES"
         ${ARGN}
     )
+
+    # Redirect output to a local staging dir when cross-compiling (no host deploy)
+    _ida_apply_cross_deploy_guard(OUTPUT_DIR "${OUTPUT_DIR}" "${NAME}" FALSE)
 
     # Create the addon as a shared library
     add_library(${NAME} SHARED ${ARG_SOURCES})
@@ -248,6 +267,10 @@ function(ida_add_plugin NAME)
 
         message(STATUS "${NAME}: deploying with metadata to ${OUTPUT_DIR}")
     endif()
+
+    # Keep the metadata copy and per-config output pinning consistent with the
+    # cross-compile staging redirect applied inside _ida_create_addon_internal.
+    _ida_apply_cross_deploy_guard(OUTPUT_DIR "${OUTPUT_DIR}" "${NAME}" TRUE)
 
     # Reconstruct argument list without METADATA_JSON for internal function
     set(INTERNAL_ARGS "")

--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -1,8 +1,8 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2019-2026 Elias Bachaalany
+# SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
 #
-# Copyright (c) Elias Bachaalany
+# This file is licensed under the Human-Origin Source License v1.0.
+# See LICENSE.
 
 # utilities.cmake - Utility functions for IDA SDK
 

--- a/idasdkConfig.cmake
+++ b/idasdkConfig.cmake
@@ -1,19 +1,26 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2019-2026 Elias Bachaalany
+# SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
 #
-# Copyright (c) Elias Bachaalany
+# This file is licensed under the Human-Origin Source License v1.0.
+# See LICENSE.
 
 # idasdkConfig.cmake
 # CMake package configuration for IDA SDK
 
-# Set IDASDK directory
-if(NOT DEFINED IDASDK)
+# Set IDASDK directory. A -DIDASDK=<path> cache variable takes precedence over
+# the IDASDK environment variable (bootstrap.cmake already applies this when used).
+if(NOT DEFINED IDASDK OR IDASDK STREQUAL "")
     if(DEFINED ENV{IDASDK})
         set(IDASDK "$ENV{IDASDK}")
     else()
-        message(FATAL_ERROR "IDASDK environment variable not set")
+        message(FATAL_ERROR "IDASDK not set. Pass -DIDASDK=<path> or set the IDASDK environment variable.")
     endif()
+endif()
+
+# Auto-detect GitHub SDK layout (files under src/) for the no-bootstrap path,
+# so -DIDASDK may point at either the SDK root or its src/ directory.
+if(NOT EXISTS "${IDASDK}/include/pro.h" AND EXISTS "${IDASDK}/src/include/pro.h")
+    set(IDASDK "${IDASDK}/src")
 endif()
 
 # Set IDABIN directory (default to $IDASDK/bin if not specified)

--- a/idasdkConfigVersion.cmake
+++ b/idasdkConfigVersion.cmake
@@ -1,8 +1,8 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2019-2026 Elias Bachaalany
+# SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
 #
-# Copyright (c) Elias Bachaalany
+# This file is licensed under the Human-Origin Source License v1.0.
+# See LICENSE.
 
 # IDASDKConfigVersion.cmake
 # Version compatibility checking for IDASDK package

--- a/templates/idalib-vanilla/CMakeLists.txt
+++ b/templates/idalib-vanilla/CMakeLists.txt
@@ -1,15 +1,15 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2019-2026 Elias Bachaalany
+# SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
 #
-# Copyright (c) Elias Bachaalany
+# This file is licensed under the Human-Origin Source License v1.0.
+# See LICENSE.
 
 cmake_minimum_required(VERSION 3.27)
 project(myidalib VERSION 1.0)
 set(CMAKE_CXX_STANDARD 17)
 
 # Include IDA SDK bootstrap
-include($ENV{IDASDK}/src/cmake/bootstrap.cmake)
+include($ENV{IDASDK}/ida-cmake/bootstrap.cmake)
 find_package(idasdk REQUIRED)
 
 # Standard CMake approach - create an executable

--- a/templates/idalib-vanilla/main.cpp
+++ b/templates/idalib-vanilla/main.cpp
@@ -1,8 +1,8 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+// Copyright (c) 2019-2026 Elias Bachaalany
+// SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
 //
-// Copyright (c) Elias Bachaalany
+// This file is licensed under the Human-Origin Source License v1.0.
+// See LICENSE.
 
 #include <iostream>
 #include <ida.hpp>

--- a/templates/idalib/CMakeLists.txt
+++ b/templates/idalib/CMakeLists.txt
@@ -1,15 +1,15 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2019-2026 Elias Bachaalany
+# SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
 #
-# Copyright (c) Elias Bachaalany
+# This file is licensed under the Human-Origin Source License v1.0.
+# See LICENSE.
 
 cmake_minimum_required(VERSION 3.27)
 project(myidalib VERSION 1.0)
 set(CMAKE_CXX_STANDARD 17)
 
 # Include IDA SDK bootstrap
-include($ENV{IDASDK}/src/cmake/bootstrap.cmake)
+include($ENV{IDASDK}/ida-cmake/bootstrap.cmake)
 find_package(idasdk REQUIRED)
 
 # Convert paths to native format

--- a/templates/idalib/main.cpp
+++ b/templates/idalib/main.cpp
@@ -1,8 +1,8 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+// Copyright (c) 2019-2026 Elias Bachaalany
+// SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
 //
-// Copyright (c) Elias Bachaalany
+// This file is licensed under the Human-Origin Source License v1.0.
+// See LICENSE.
 
 #include <iostream>
 #include <ida.hpp>

--- a/templates/loader/CMakeLists.txt
+++ b/templates/loader/CMakeLists.txt
@@ -1,15 +1,15 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2019-2026 Elias Bachaalany
+# SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
 #
-# Copyright (c) Elias Bachaalany
+# This file is licensed under the Human-Origin Source License v1.0.
+# See LICENSE.
 
 cmake_minimum_required(VERSION 3.27)
 project(myloader)
 set(CMAKE_CXX_STANDARD 17)
 
 # Include IDA SDK bootstrap
-include($ENV{IDASDK}/src/cmake/bootstrap.cmake)
+include($ENV{IDASDK}/ida-cmake/bootstrap.cmake)
 find_package(idasdk REQUIRED)
 
 # Convert paths to native format

--- a/templates/loader/loader.cpp
+++ b/templates/loader/loader.cpp
@@ -1,8 +1,8 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+// Copyright (c) 2019-2026 Elias Bachaalany
+// SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
 //
-// Copyright (c) Elias Bachaalany
+// This file is licensed under the Human-Origin Source License v1.0.
+// See LICENSE.
 
 #include <ida.hpp>
 #include <idp.hpp>

--- a/templates/plugin-no-bootstrap/CMakeLists.txt
+++ b/templates/plugin-no-bootstrap/CMakeLists.txt
@@ -1,8 +1,8 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2019-2026 Elias Bachaalany
+# SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
 #
-# Copyright (c) Elias Bachaalany
+# This file is licensed under the Human-Origin Source License v1.0.
+# See LICENSE.
 
 cmake_minimum_required(VERSION 3.27)
 project(myplugin)

--- a/templates/plugin-no-bootstrap/main.cpp
+++ b/templates/plugin-no-bootstrap/main.cpp
@@ -1,8 +1,8 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+// Copyright (c) 2019-2026 Elias Bachaalany
+// SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
 //
-// Copyright (c) Elias Bachaalany
+// This file is licensed under the Human-Origin Source License v1.0.
+// See LICENSE.
 
 #include <ida.hpp>
 #include <idp.hpp>

--- a/templates/plugin-pch/CMakeLists.txt
+++ b/templates/plugin-pch/CMakeLists.txt
@@ -1,15 +1,15 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2019-2026 Elias Bachaalany
+# SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
 #
-# Copyright (c) Elias Bachaalany
+# This file is licensed under the Human-Origin Source License v1.0.
+# See LICENSE.
 
 cmake_minimum_required(VERSION 3.27)
 project(myplugin)
 set(CMAKE_CXX_STANDARD 17)
 
 # Include IDA SDK bootstrap
-include($ENV{IDASDK}/src/cmake/bootstrap.cmake)
+include($ENV{IDASDK}/ida-cmake/bootstrap.cmake)
 find_package(idasdk REQUIRED)
 
 # Convert paths to native format

--- a/templates/plugin-pch/main.cpp
+++ b/templates/plugin-pch/main.cpp
@@ -1,8 +1,8 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+// Copyright (c) 2019-2026 Elias Bachaalany
+// SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
 //
-// Copyright (c) Elias Bachaalany
+// This file is licensed under the Human-Origin Source License v1.0.
+// See LICENSE.
 
 /**
  * @file main.cpp

--- a/templates/plugin-pch/pch.h
+++ b/templates/plugin-pch/pch.h
@@ -1,8 +1,8 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+// Copyright (c) 2019-2026 Elias Bachaalany
+// SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
 //
-// Copyright (c) Elias Bachaalany
+// This file is licensed under the Human-Origin Source License v1.0.
+// See LICENSE.
 
 /**
  * @file pch.h

--- a/templates/plugin-pch/plugin.h
+++ b/templates/plugin-pch/plugin.h
@@ -1,8 +1,8 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+// Copyright (c) 2019-2026 Elias Bachaalany
+// SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
 //
-// Copyright (c) Elias Bachaalany
+// This file is licensed under the Human-Origin Source License v1.0.
+// See LICENSE.
 
 /**
  * @file plugin.h

--- a/templates/plugin-vanilla/CMakeLists.txt
+++ b/templates/plugin-vanilla/CMakeLists.txt
@@ -1,15 +1,15 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2019-2026 Elias Bachaalany
+# SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
 #
-# Copyright (c) Elias Bachaalany
+# This file is licensed under the Human-Origin Source License v1.0.
+# See LICENSE.
 
 cmake_minimum_required(VERSION 3.27)
 project(myplugin)
 set(CMAKE_CXX_STANDARD 17)
 
 # Include IDA SDK bootstrap
-include($ENV{IDASDK}/src/cmake/bootstrap.cmake)
+include($ENV{IDASDK}/ida-cmake/bootstrap.cmake)
 find_package(idasdk REQUIRED)
 
 # Standard CMake approach - create a shared library

--- a/templates/plugin-vanilla/main.cpp
+++ b/templates/plugin-vanilla/main.cpp
@@ -1,8 +1,8 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+// Copyright (c) 2019-2026 Elias Bachaalany
+// SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
 //
-// Copyright (c) Elias Bachaalany
+// This file is licensed under the Human-Origin Source License v1.0.
+// See LICENSE.
 
 #include <ida.hpp>
 #include <idp.hpp>

--- a/templates/plugin/CMakeLists.txt
+++ b/templates/plugin/CMakeLists.txt
@@ -1,15 +1,15 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2019-2026 Elias Bachaalany
+# SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
 #
-# Copyright (c) Elias Bachaalany
+# This file is licensed under the Human-Origin Source License v1.0.
+# See LICENSE.
 
 cmake_minimum_required(VERSION 3.27)
 project(myplugin)
 set(CMAKE_CXX_STANDARD 17)
 
 # Include IDA SDK bootstrap
-include($ENV{IDASDK}/src/cmake/bootstrap.cmake)
+include($ENV{IDASDK}/ida-cmake/bootstrap.cmake)
 find_package(idasdk REQUIRED)
 
 # Convert paths to native format

--- a/templates/plugin/main.cpp
+++ b/templates/plugin/main.cpp
@@ -1,8 +1,8 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+// Copyright (c) 2019-2026 Elias Bachaalany
+// SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
 //
-// Copyright (c) Elias Bachaalany
+// This file is licensed under the Human-Origin Source License v1.0.
+// See LICENSE.
 
 #include <ida.hpp>
 #include <idp.hpp>

--- a/templates/procmod/CMakeLists.txt
+++ b/templates/procmod/CMakeLists.txt
@@ -1,15 +1,15 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2019-2026 Elias Bachaalany
+# SPDX-License-Identifier: LicenseRef-Human-Origin-Source-1.0
 #
-# Copyright (c) Elias Bachaalany
+# This file is licensed under the Human-Origin Source License v1.0.
+# See LICENSE.
 
 cmake_minimum_required(VERSION 3.27)
 project(i51)
 set(CMAKE_CXX_STANDARD 17)
 
 # Include IDA SDK bootstrap
-include($ENV{IDASDK}/src/cmake/bootstrap.cmake)
+include($ENV{IDASDK}/ida-cmake/bootstrap.cmake)
 find_package(idasdk REQUIRED)
 
 # Add processor module


### PR DESCRIPTION
Single squashed commit. CI is green across all 11 jobs (9.2/9.3/9.4 x Linux/macOS/Windows + Windows-ARM64 cross + macOS universal).

## What's in it
- **-DIDASDK cache override** — select an SDK per build without changing the `IDASDK` env var (`bootstrap.cmake`, `idasdkConfig.cmake`).
- **Windows-on-ARM (ARM64)** — target detection via `-A ARM64` / `CMAKE_SYSTEM_PROCESSOR`, linking against the SDK's `arm64_win_64` libs (requires SDK 9.4+). Cross-built addons are staged locally instead of deployed into a mismatched host IDA (`-DIDA_FORCE_DEPLOY=ON` to override).
- **Independent of the SDK's vendored cmake** — templates include `$IDASDK/ida-cmake/bootstrap.cmake` (our own dir), never the SDK's `src/cmake` (which IDA SDK 9.4 vendors). See `cmake/ACKNOWLEDGMENTS.md` in the SDK, which credits this project.
- **Multi-SDK CI** — builds all templates across SDK 9.2/9.3/9.4 x OS, pinned to the latest packaging per version (`v9.2.0-sdk.1`, `v9.3.1-sdk.1`, `v9.4.0-release`), plus a 9.4-only Windows ARM64 cross job. ida-cmake is installed via `git clone --local .` so CI tests the checked-out commit; `ci.cmake` gains `IDA_CI_ARCH`.
- **Apple linker fix** — use `-Wl,-dead_strip` on Apple (ld64) instead of `-Wl,--gc-sections`, and match `AppleClang` in the GNU/Clang compiler branch. Fixes #25.
- **License** — switch from MPL 2.0 to the Human-Origin Source License v1.0 (per-file headers + SPDX). Reviewers: note the license change.

## Coverage notes
- CI builds 7 of the 10 templates; `debmod`, `plugin-pch`, `idalib-delayload` are not yet in the CI list.
- No `linux-arm64` leg (runners are x64). 9.1 is not on the Hex-Rays GitHub repo (earliest tag is 9.2), so it's not in CI.